### PR TITLE
work-around gcc 4.9 demotion to signed

### DIFF
--- a/tinyprintf.c
+++ b/tinyprintf.c
@@ -60,6 +60,11 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 # define SIZEOF_INT __SIZEOF_INT__
 #endif
 
+#ifdef __GNUC__
+# define _TFP_GCC_NO_INLINE_  __attribute__ ((noinline))
+#else
+# define _TFP_GCC_NO_INLINE_
+#endif
 
 /*
  * Implementation
@@ -77,7 +82,8 @@ struct param {
 
 
 #ifdef PRINTF_LONG_LONG_SUPPORT
-static void ulli2a(unsigned long long int num, struct param *p)
+static void _TFP_GCC_NO_INLINE_ ulli2a(
+    unsigned long long int num, struct param *p)
 {
     int n = 0;
     unsigned long long int d = 1;


### PR DESCRIPTION
when compiling the inlined version of this loop in ulli2a:
    while (num / d >= p->base)
        d *= p->base;
gcc 4.9 -O3 seems to be confused for base = 10 and base 16, seems to
consider "num" as signed, which means that ULLONG_MAX is considered <
p->base, and d stays == 1 instead of 100...00.

This patch asks gcc not to inline too much, so that it doesn't
specialize the function for bases 10, 16 and doesn't get confused with
signedness.

Tested:
  make clean all with gcc 4.9.
