### PR TITLE
Using stddef.h and fixing warning

### DIFF
--- a/tinyprintf.c
+++ b/tinyprintf.c
@@ -380,6 +380,7 @@ void tfp_format(void *putp, putcf putf, const char *fmt, va_list va)
                 lng = 2;
 # endif
 #endif
+            //-fallthrough
             case 'x':
             case 'X':
                 p.base = 16;

--- a/tinyprintf.c
+++ b/tinyprintf.c
@@ -39,7 +39,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  * Configuration adjustments
  */
 #ifdef PRINTF_SIZE_T_SUPPORT
-#include <sys/types.h>
+#include <stddef.h>
 #endif
 
 #ifdef PRINTF_LONG_LONG_SUPPORT

--- a/tinyprintf.h
+++ b/tinyprintf.h
@@ -126,7 +126,7 @@ regs Kusti, 23.10.2004
 /* Optional external types dependencies */
 
 #if TINYPRINTF_DEFINE_TFP_SPRINTF
-# include <sys/types.h>  /* size_t */
+# include <stddef.h>  /* size_t */
 #endif
 
 /* Declarations */


### PR DESCRIPTION
size_t is provided by the stddef.h header file. This will make tinyprintf compile with the IAR compiler for ARM Cortex-M. I also fixed a fallthrough warning that gcc complains about.