### PR TITLE
Use "unsigned char:1" for flags

### DIFF
--- a/tinyprintf.c
+++ b/tinyprintf.c
@@ -70,14 +70,15 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  * Implementation
  */
 struct param {
-    char lz:1;          /**<  Leading zeros */
-    char alt:1;         /**<  alternate form */
-    char uc:1;          /**<  Upper case (for base16 only) */
-    char align_left:1;  /**<  0 == align right (default), 1 == align left */
-    unsigned int width; /**<  field width */
-    char sign;          /**<  The sign to display (if any) */
-    unsigned int base;  /**<  number base (e.g.: 8, 10, 16) */
-    char *bf;           /**<  Buffer to output */
+    unsigned char lz:1;  /**<  Leading zeros */
+    unsigned char alt:1; /**<  alternate form */
+    unsigned char uc:1;  /**<  Upper case (for base16 only) */
+    unsigned char align_left:1;
+                         /**<  0 == align right (default), 1 == align left */
+    unsigned int width;  /**<  field width */
+    char sign;           /**<  The sign to display (if any) */
+    unsigned int base;   /**<  number base (e.g.: 8, 10, 16) */
+    char *bf;            /**<  Buffer to output */
 };
 
 


### PR DESCRIPTION
"char" is treated, at least in many cases, as signed values. Having that field as 1 bit means it can be treated as one sign bit, no data bits. Thus only values 0 and -1 will be accepted

It seems to differ between versions of the compiler. But in any case, explicitly defining it as unsigned means only the values 0 and 1 will be accepted, and therefore there shouldn't be any issues between compiler versions.

This is a fix for an issue I had using:
```
gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
```

Was compiling with flags:
```
gcc -g -O3 -Wdouble-promotion -Wall -Werror -Wpedantic
```

And the errors I got was:
```
src/vendor/tinyprintf/tinyprintf.c: In function ‘tfp_format’:
src/vendor/tinyprintf/tinyprintf.c:282:36: error: overflow in conversion from ‘int’ to ‘signed char:1’ changes value from ‘1’ to ‘-1’ [-Werror=overflow]
  282 |                     p.align_left = 1;
      |                                    ^
src/vendor/tinyprintf/tinyprintf.c:285:28: error: overflow in conversion from ‘int’ to ‘signed char:1’ changes value from ‘1’ to ‘-1’ [-Werror=overflow]
  285 |                     p.lz = 1;
      |                            ^
src/vendor/tinyprintf/tinyprintf.c:288:29: error: overflow in conversion from ‘int’ to ‘signed char:1’ changes value from ‘1’ to ‘-1’ [-Werror=overflow]
  288 |                     p.alt = 1;
      |                             ^
src/vendor/tinyprintf/tinyprintf.c:305:22: error: overflow in conversion from ‘int’ to ‘signed char:1’ changes value from ‘1’ to ‘-1’ [-Werror=overflow]
  305 |               p.lz = 1;  /* zero-padding */
      |                      ^
src/vendor/tinyprintf/tinyprintf.c:374:25: error: overflow in conversion from ‘int’ to ‘signed char:1’ changes value from ‘1’ to ‘-1’ [-Werror=overflow]
  374 |                 p.alt = 1;
      |                         ^
```

This patch should solve it.

I've been trying to also add the corresponding warning to the make file, but can't seem to reproduce it in tinyprintfs build environment.